### PR TITLE
PLF-7091 Feature/jbosseap 7

### DIFF
--- a/exo.kernel.container/src/main/java/org/exoplatform/container/WebAppInitContext.java
+++ b/exo.kernel.container/src/main/java/org/exoplatform/container/WebAppInitContext.java
@@ -39,6 +39,11 @@ public class WebAppInitContext
    private final ServletContext servletContext;
 
    /**
+    * The servlet context name of the web application
+    */
+   private final String servletContextName;
+
+   /**
     * The class loader of the web application;
     */
    private final ClassLoader webappClassLoader;
@@ -47,6 +52,7 @@ public class WebAppInitContext
    {
       this.servletContext = servletContext;
       this.webappClassLoader = Thread.currentThread().getContextClassLoader();
+      this.servletContextName = ContainerUtil.getServletContextName(servletContext);
    }
 
    public ServletContext getServletContext()
@@ -56,7 +62,7 @@ public class WebAppInitContext
 
    public String getServletContextName()
    {
-      return ContainerUtil.getServletContextName(servletContext);
+      return servletContextName;
    }
 
    public ClassLoader getWebappClassLoader()


### PR DESCRIPTION
Make sure to have the same behavior when requesting Context Path on JBoss EAP and Tomcat.
In fact in JBoss EAP 7, when the request is dispatched from portal.war to another war application (portlet context), the context path is changed (request.getContextPath changes). But in tomcat 7/8.5, the original context path is maintained the same during the request dispatch. (/portal)
This PR ensures that the context path remain the same even when the request is dispatched to another WAR application.