### PR TITLE
bcel snapshot library doesn't exist

### DIFF
--- a/exo.kernel.container/pom.xml
+++ b/exo.kernel.container/pom.xml
@@ -142,7 +142,7 @@
                <dependency>
 			         <groupId>org.apache.bcel</groupId>
 			         <artifactId>bcel</artifactId>
-			         <version>6.0-SNAPSHOT</version>
+			         <version>6.0</version>
 		         </dependency>
            </dependencies>
          </plugin>


### PR DESCRIPTION
How can you compile using a third party library spapshot version?? BCEL 6.0-SNAPSHOT doesn't exist. A stable 6.0 version is on the maven repositories. Would you change it?